### PR TITLE
mbx docs as markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 [![Build Status](https://travis-ci.org/mapbox/mbx-cli.svg)](https://travis-ci.org/mapbox/mbx-cli) [![Coverage Status](https://coveralls.io/repos/mapbox/mbx-cli/badge.svg?branch=master&service=github)](https://coveralls.io/github/mapbox/mbx-cli?branch=master)
 
 Command line interface to Mapbox Web Services
+
+Documentation
+
+* [main command](docs/mbx.md) and setting up access tokens
+* [geocoding](docs/geocoding.md)
+

--- a/docs/geocoding.md
+++ b/docs/geocoding.md
@@ -1,0 +1,50 @@
+# Geocoder
+
+CLI for the [Geocoding API](https://www.mapbox.com/developers/api/geocoding/)
+
+The ``mbx-geocode`` command can do forward or reverse geocoding.
+
+- Forward (place names ⇢ longitude, latitude)
+- Reverse (longitude, latitude ⇢ place names)
+
+## Usage
+
+```
+$ mbx geocode --help
+Usage: mbx geocode [OPTIONS] [QUERY]
+
+    This command returns places matching an address (forward mode) or places
+    matching coordinates (reverse mode).
+
+    In forward (the default) mode the query argument shall be an address such
+    as '1600 pennsylvania ave nw'.
+
+    $ mbx geocode '1600 pennsylvania ave nw'
+
+    In reverse mode the query argument shall be a JSON encoded array of
+    longitude and latitude (in that order) in decimal degrees.
+
+    $ mbx geocode --reverse '[-77.4371, 37.5227]'
+
+    An access token is required, see `mbx --help`.
+
+Options:
+    --forward / --reverse  Perform a forward or reverse geocode. [default:
+                            forward]
+    -i, --include          Include HTTP headers in the output.
+    --lat FLOAT            Bias results toward this latitude (decimal degrees).
+                            --lon is also required.
+    --lon FLOAT            Bias results toward this longitude (decimal degrees).
+                            --lat is also required.
+    -t, --place-type NAME  Restrict results to one or more of these place types:
+                            ['address', 'country', 'place', 'poi', 'postcode',
+                            'region'].
+    -o, --output TEXT      Save output to a file.
+    --help                 Show this message and exit.
+```
+
+Its output can be piped to [geojsonio](http://geojson.io) using
+[geojsonio-cli](https://github.com/mapbox/geojsonio-cli>)
+
+    $ mbx geocode 'Chester, NJ' | geojsonio
+

--- a/docs/geocoding.md
+++ b/docs/geocoding.md
@@ -2,7 +2,7 @@
 
 CLI for the [Geocoding API](https://www.mapbox.com/developers/api/geocoding/)
 
-The ``mbx-geocode`` command can do forward or reverse geocoding.
+The ``mbx-geocoding`` command can do forward or reverse geocoding.
 
 - Forward (place names ⇢ longitude, latitude)
 - Reverse (longitude, latitude ⇢ place names)
@@ -10,41 +10,41 @@ The ``mbx-geocode`` command can do forward or reverse geocoding.
 ## Usage
 
 ```
-$ mbx geocode --help
-Usage: mbx geocode [OPTIONS] [QUERY]
+$ mbx geocoding --help
+Usage: mbx geocoding [OPTIONS] [QUERY]
 
-    This command returns places matching an address (forward mode) or places
-    matching coordinates (reverse mode).
+  This command returns places matching an address (forward mode) or places
+  matching coordinates (reverse mode).
 
-    In forward (the default) mode the query argument shall be an address such
-    as '1600 pennsylvania ave nw'.
+  In forward (the default) mode the query argument shall be an address such
+  as '1600 pennsylvania ave nw'.
 
-    $ mbx geocode '1600 pennsylvania ave nw'
+    $ mbx geocoding '1600 pennsylvania ave nw'
 
-    In reverse mode the query argument shall be a JSON encoded array of
-    longitude and latitude (in that order) in decimal degrees.
+  In reverse mode the query argument shall be a JSON encoded array of
+  longitude and latitude (in that order) in decimal degrees.
 
-    $ mbx geocode --reverse '[-77.4371, 37.5227]'
+    $ mbx geocoding --reverse '[-77.4371, 37.5227]'
 
-    An access token is required, see `mbx --help`.
+  An access token is required, see `mbx --help`.
 
 Options:
-    --forward / --reverse  Perform a forward or reverse geocode. [default:
-                            forward]
-    -i, --include          Include HTTP headers in the output.
-    --lat FLOAT            Bias results toward this latitude (decimal degrees).
-                            --lon is also required.
-    --lon FLOAT            Bias results toward this longitude (decimal degrees).
-                            --lat is also required.
-    -t, --place-type NAME  Restrict results to one or more of these place types:
-                            ['address', 'country', 'place', 'poi', 'postcode',
-                            'region'].
-    -o, --output TEXT      Save output to a file.
-    --help                 Show this message and exit.
+  --forward / --reverse  Perform a forward or reverse geocode. [default:
+                         forward]
+  -i, --include          Include HTTP headers in the output.
+  --lat FLOAT            Bias results toward this latitude (decimal degrees).
+                         --lon is also required.
+  --lon FLOAT            Bias results toward this longitude (decimal degrees).
+                         --lat is also required.
+  -t, --place-type NAME  Restrict results to one or more of these place types:
+                         ['address', 'country', 'neighborhood', 'place',
+                         'poi', 'postcode', 'region'].
+  -o, --output TEXT      Save output to a file.
+  --help                 Show this message and exit.
 ```
 
 Its output can be piped to [geojsonio](http://geojson.io) using
 [geojsonio-cli](https://github.com/mapbox/geojsonio-cli>)
 
-    $ mbx geocode 'Chester, NJ' | geojsonio
+    $ mbx geocoding 'Chester, NJ' | geojsonio
 

--- a/docs/mbx.md
+++ b/docs/mbx.md
@@ -1,0 +1,48 @@
+# mbx
+
+`mbx` is a command line interface to Mapbox web services. 
+
+## Access Token
+
+Mapbox web services require an access token. Your token is shown on the
+https://www.mapbox.com/developers/api/ page when you are logged in. The
+token can be provided on the command line
+
+    $ mbx --access-token MY_TOKEN ...
+
+or as an environment variable named MAPBOX_ACCESS_TOKEN or
+MapboxAccessToken.
+
+    $ export MAPBOX_ACCESS_TOKEN=MY_TOKEN
+    $ mbx ...
+
+## Usage
+
+```
+$ mbx --help
+Usage: mbx [OPTIONS] COMMAND [ARGS]...
+
+    This is the command line interface to Mapbox web services.
+
+    Mapbox web services require an access token. Your token is shown on the
+    https://www.mapbox.com/developers/api/ page when you are logged in. The
+    token can be provided on the command line
+
+    $ mbx --access-token MY_TOKEN ...
+
+    or as an environment variable named MAPBOX_ACCESS_TOKEN or
+    MapboxAccessToken.
+
+    $ export MAPBOX_ACCESS_TOKEN=MY_TOKEN
+    $ mbx ...
+
+Options:
+    --access-token TEXT  Your Mapbox access token.
+    -v, --verbose        Increase verbosity.
+    --version            Show the version and exit.
+    -q, --quiet          Decrease verbosity.
+    --help               Show this message and exit.
+
+Commands:
+    geocode  Geocode an address or coordinates.
+```

--- a/mbx/scripts/geocoding.py
+++ b/mbx/scripts/geocoding.py
@@ -69,12 +69,12 @@ def geocoding(ctx, query, forward, include_headers, lat, lon, place_type, output
     In forward (the default) mode the query argument shall be an address
     such as '1600 pennsylvania ave nw'.
 
-      $ mbx geocode '1600 pennsylvania ave nw'
+      $ mbx geocoding '1600 pennsylvania ave nw'
 
     In reverse mode the query argument shall be a JSON encoded array
     of longitude and latitude (in that order) in decimal degrees.
 
-      $ mbx geocode --reverse '[-77.4371, 37.5227]'
+      $ mbx geocoding --reverse '[-77.4371, 37.5227]'
 
     An access token is required, see `mbx --help`.
     """


### PR DESCRIPTION
A rough outline for how we might structure docs. 

* High level overview in README, linking to md pages
* one `doc/*.md` page per command

Eventually these will be jekyllified but for now this may work as an interim step.

Resolved #2 