### PR TITLE
Add dataset api support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ pip install mapboxcli
 * [staticmap](#staticmap)
 * [surface](#surface)
 * [upload](#upload)
+* [datasets](#datasets)
 
 For any command that takes waypoints or features as an input you can either specify:
 
@@ -197,4 +198,239 @@ Usage: mapbox upload [OPTIONS] TILESET INFILE
 Options:
   --name TEXT  Name for the data upload
   --help       Show this message and exit.
+```
+
+### datasets
+```
+Usage: mapbox datasets [OPTIONS] COMMAND [ARGS]...
+
+  Read and write GeoJSON from Mapbox-hosted datasets
+
+  All endpoints require authentication. An access token with appropriate
+  dataset scopes is required, see `mapbox --help`.
+
+  Note that this API is currently a limited-access beta.
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  batch-update-feature  Insert, update, or delete multiple features in a
+                        dataset
+  create                Create an empty dataset
+  create-tileset        Generate a tileset from a dataset
+  delete-dataset        Delete a dataset
+  delete-feature        Delete a single feature from a dataset
+  list                  List datasets
+  list-features         List features in a dataset
+  put-feature           Insert or update a single feature in a dataset
+  read-dataset          Return information about a dataset
+  read-feature          Read a single feature from a dataset
+  update-dataset        Update information about a dataset
+```
+
+### datasets list
+```
+Usage: mapbox datasets list [OPTIONS]
+
+  List datasets.
+
+  Prints a list of objects describing datasets.
+
+      $ mapbox dataset list
+
+  All endpoints require authentication. An access token with `datasets:read`
+  scope is required, see `mapbox --help`.
+
+Options:
+  -o, --output TEXT  Save output to a file
+  --help             Show this message and exit.
+```
+
+### datasets create
+```
+Usage: mapbox datasets create [OPTIONS]
+
+  Create a new dataset.
+
+  Prints a JSON object containing the attributes of the new dataset.
+
+      $ mapbox dataset create
+
+  All endpoints require authentication. An access token with
+  `datasets:write` scope is required, see `mapbox --help`.
+
+Options:
+  -n, --name TEXT         Name for the dataset
+  -d, --description TEXT  Description for the dataset
+  --help                  Show this message and exit.
+```
+
+### datasets read-dataset
+```
+Usage: mapbox datasets read-dataset [OPTIONS] DATASET
+
+  Read the attributes of a dataset.
+
+  Prints a JSON object containing the attributes of a dataset. The
+  attributes: owner (a Mapbox account), id (dataset id), created (Unix
+  timestamp), modified (timestamp), name (string), and description (string).
+
+      $ mapbox dataset read-dataset dataset-id
+
+  All endpoints require authentication. An access token with `datasets:read`
+  scope is required, see `mapbox --help`.
+
+Options:
+  -o, --output TEXT  Save output to a file
+  --help             Show this message and exit.
+```
+
+### datasets update-dataset
+```
+Usage: mapbox datasets update-dataset [OPTIONS] DATASET
+
+  Update the name and description of a dataset.
+
+  Prints a JSON object containing the updated dataset attributes.
+
+      $ mapbox dataset update-dataset dataset-id
+
+  All endpoints require authentication. An access token with
+  `datasets:write` scope is required, see `mapbox --help`.
+
+Options:
+  -n, --name TEXT         Name for the dataset
+  -d, --description TEXT  Description for the dataset
+  --help                  Show this message and exit.
+```
+
+### datasets delete-dataset
+```
+Usage: mapbox datasets delete-dataset [OPTIONS] DATASET
+
+  Delete a dataset.
+
+      $ mapbox dataset delete-dataset dataset-id
+
+  All endpoints require authentication. An access token with
+  `datasets:write` scope is required, see `mapbox --help`.
+
+Options:
+  --help  Show this message and exit.
+```
+
+### datasets list-features
+```
+Usage: mapbox datasets list-features [OPTIONS] DATASET
+
+  Get features of a dataset.
+
+  Prints the features of the dataset as a GeoJSON feature collection.
+
+      $ mapbox dataset list-features dataset-id
+
+  All endpoints require authentication. An access token with `datasets:read`
+  scope is required, see `mapbox --help`.
+
+Options:
+  -r, --reverse TEXT  Read features in reverse
+  -s, --start TEXT    Feature id to begin reading from
+  -l, --limit TEXT    Maximum number of features to return
+  -o, --output TEXT   Save output to a file
+  --help              Show this message and exit.
+```
+
+### datasets put-feature
+```
+Usage: mapbox datasets put-feature [OPTIONS] DATASET FID [FEATURE]
+
+  Create or update a dataset feature.
+
+  The semantics of HTTP PUT apply: if the dataset has no feature with the
+  given `fid` a new feature will be created. Returns a GeoJSON
+  representation of the new or updated feature.
+
+      $ mapbox dataset put-feature dataset-id feature-id 'geojson-feature'
+
+  All endpoints require authentication. An access token with
+  `datasets:write` scope is required, see `mapbox --help`.
+
+Options:
+  -i, --input TEXT  File containing a feature to put
+  --help            Show this message and exit.
+```
+
+### datasets read-feature
+```
+Usage: mapbox datasets read-feature [OPTIONS] DATASET FID
+
+  Read a dataset feature.
+
+  Prints a GeoJSON representation of the feature.
+
+      $ mapbox dataset read-feature dataset-id feature-id
+
+  All endpoints require authentication. An access token with `datasets:read`
+  scope is required, see `mapbox --help`.
+
+Options:
+  -o, --output TEXT  Save output to a file
+  --help             Show this message and exit.
+```
+
+### datasets delete-feature
+```
+Usage: mapbox datasets delete-feature [OPTIONS] DATASET FID
+
+  Delete a feature.
+
+      $ mapbox dataset delete-feature dataset-id feature-id
+
+  All endpoints require authentication. An access token with
+  `datasets:write` scope is required, see `mapbox --help`.
+
+Options:
+  --help  Show this message and exit.
+```
+
+### datasets batch-update-feature
+```
+Usage: mapbox datasets batch-update-feature [OPTIONS] DATASET [PUTS] [DELETES]
+
+  Update features of a dataset.
+
+  Up to 100 features may be deleted or modified in one request. PUTS should
+  be a JSON array of GeoJSON features to insert or updated. DELETES should
+  be a JSON array of feature ids to be deleted.
+
+      $ mapbox dataset batch-update-feature dataset-id 'puts' 'deletes'
+
+  All endpoints require authentication. An access token with
+  `datasets:write` scope is required, see `mapbox --help`.
+
+Options:
+  -i, --input TEXT  File containing features to insert, update, and/or delete
+  --help            Show this message and exit.
+```
+
+### datasets create-tileset
+```
+Usage: mapbox datasets create-tileset [OPTIONS] DATASET TILESET
+
+  Create a vector tileset from a dataset.
+
+      $ mapbox dataset create-tileset dataset-id username.data
+
+  Note that the tileset must start with your username and the dataset must
+  be one that you own. To view processing status, visit
+  https://www.mapbox.com/data/. You may not generate another tilesets from
+  the same dataset until the first processing job has completed.
+
+  All endpoints require authentication. An access token with `uploads:write`
+  scope is required, see `mapbox --help`.
+
+Options:
+  -n, --name TEXT  Name for the tileset
+  --help           Show this message and exit.
 ```

--- a/mapboxcli/scripts/datasets.py
+++ b/mapboxcli/scripts/datasets.py
@@ -141,10 +141,13 @@ def delete_dataset(ctx, dataset):
         raise MapboxCLIException(res.text.strip())
 
 @dataset.command(name="list-features", short_help="List features in a dataset")
-@click.option('--output', '-o', default='-', help="Save output to a file")
 @click.argument('dataset', required=True)
+@click.option('--reverse', '-r', default=False, help="Read features in reverse")
+@click.option('--start', '-s', default=None, help="Feature id to begin reading from")
+@click.option('--limit', '-l', default=None, help="Maximum number of features to return")
+@click.option('--output', '-o', default='-', help="Save output to a file")
 @click.pass_context
-def list_features(ctx, dataset, output):
+def list_features(ctx, dataset, reverse, start, limit, output):
     """Get features of a dataset.
 
     Prints the features of the dataset as a GeoJSON feature collection.
@@ -157,7 +160,7 @@ def list_features(ctx, dataset, output):
 
     stdout = click.open_file(output, 'w')
     service = ctx.obj.get('service')
-    res = service.list_features(dataset)
+    res = service.list_features(dataset, reverse, start, limit)
 
     if res.status_code == 200:
         click.echo(res.text, file=stdout)
@@ -246,7 +249,7 @@ def delete_feature(ctx, dataset, fid):
         raise MapboxCLIException(res.text.strip())
 
 @dataset.command(name="batch-update-feature",
-    short_help="Insert or update multiple features in a dataset")
+    short_help="Insert, update, or delete multiple features in a dataset")
 @click.argument('dataset', required=True)
 @click.argument('puts', required=False, default=None)
 @click.argument('deletes', required=False, default=None)

--- a/mapboxcli/scripts/datasets.py
+++ b/mapboxcli/scripts/datasets.py
@@ -256,7 +256,7 @@ def delete_feature(ctx, dataset, fid):
 @click.option('--input', '-i', default='-',
     help="File containing features to insert, update, and/or delete")
 @click.pass_context
-def delete_feature(ctx, dataset, puts, deletes, input):
+def batch_update_features(ctx, dataset, puts, deletes, input):
     """Update features of a dataset.
 
     Up to 100 features may be deleted or modified in one request. PUTS

--- a/mapboxcli/scripts/datasets.py
+++ b/mapboxcli/scripts/datasets.py
@@ -288,3 +288,35 @@ def delete_feature(ctx, dataset, puts, deletes, input):
         click.echo(res.text)
     else:
         raise MapboxCLIException(res.text.strip())
+
+@dataset.command(name="create-tileset",
+    short_help="Generate a tileset from a dataset")
+@click.argument('dataset', required=True)
+@click.argument('tileset', required=True)
+@click.option('--name', '-n', default=None, help="Name for the tileset")
+@click.pass_context
+def create_tileset(ctx, dataset, tileset, name):
+    """Create a vector tileset from a dataset.
+
+        $ mapbox dataset create-tileset dataset-id username.data
+
+    Note that the tileset must start with your username and the dataset must be
+    one that you own. To view processing status, visit
+    https://www.mapbox.com/data/. You may not generate another tilesets from
+    the same dataset until the first processing job has completed.
+
+    All endpoints require authentication. An access token with
+    `uploads:write` scope is required, see `mapbox --help`.
+    """
+
+    access_token = (ctx.obj and ctx.obj.get('access_token')) or None
+    service = mapbox.Uploader(access_token=access_token)
+
+    uri = "mapbox://datasets/{username}/{dataset}".format(username=tileset.split('.')[0], dataset=dataset)
+
+    res = service.create(uri, tileset, name)
+
+    if res.status_code == 201:
+        click.echo(res.text)
+    else:
+        raise MapboxCLIException(res.text.strip())

--- a/mapboxcli/scripts/datasets.py
+++ b/mapboxcli/scripts/datasets.py
@@ -6,7 +6,7 @@ from .helpers import MapboxCLIException
 
 @click.group(short_help="Read and write from Mapbox-hosted datasets")
 @click.pass_context
-def dataset(ctx):
+def datasets(ctx):
     """Read and write GeoJSON from Mapbox-hosted datasets
 
     All endpoints require authentication. An access token with
@@ -19,7 +19,7 @@ def dataset(ctx):
     service = mapbox.Datasets(access_token=access_token)
     ctx.obj['service'] = service
 
-@dataset.command(short_help="List datasets")
+@datasets.command(short_help="List datasets")
 @click.option('--output', '-o', default='-', help="Save output to a file")
 @click.pass_context
 def list(ctx, output):
@@ -42,7 +42,7 @@ def list(ctx, output):
     else:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(short_help="Create an empty dataset")
+@datasets.command(short_help="Create an empty dataset")
 @click.option('--name', '-n', default=None, help="Name for the dataset")
 @click.option('--description', '-d', default=None,
     help="Description for the dataset")
@@ -67,7 +67,7 @@ def create(ctx, name, description):
     else:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(name="read-dataset",
+@datasets.command(name="read-dataset",
     short_help="Return information about a dataset")
 @click.argument('dataset', required=True)
 @click.option('--output', '-o', default='-', help="Save output to a file")
@@ -95,7 +95,7 @@ def read_dataset(ctx, dataset, output):
     else:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(name="update-dataset",
+@datasets.command(name="update-dataset",
     short_help="Update information about a dataset")
 @click.argument('dataset', required=True)
 @click.option('--name', '-n', default=None, help="Name for the dataset")
@@ -122,7 +122,7 @@ def update_dataset(ctx, dataset, name, description):
     else:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(name="delete-dataset", short_help="Delete a dataset")
+@datasets.command(name="delete-dataset", short_help="Delete a dataset")
 @click.argument('dataset', required=True)
 @click.pass_context
 def delete_dataset(ctx, dataset):
@@ -140,7 +140,7 @@ def delete_dataset(ctx, dataset):
     if res.status_code != 204:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(name="list-features", short_help="List features in a dataset")
+@datasets.command(name="list-features", short_help="List features in a dataset")
 @click.argument('dataset', required=True)
 @click.option('--reverse', '-r', default=False, help="Read features in reverse")
 @click.option('--start', '-s', default=None, help="Feature id to begin reading from")
@@ -167,7 +167,7 @@ def list_features(ctx, dataset, reverse, start, limit, output):
     else:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(name="read-feature",
+@datasets.command(name="read-feature",
     short_help="Read a single feature from a dataset")
 @click.argument('dataset', required=True)
 @click.argument('fid', required=True)
@@ -193,7 +193,7 @@ def read_feature(ctx, dataset, fid, output):
     else:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(name="put-feature",
+@datasets.command(name="put-feature",
     short_help="Insert or update a single feature in a dataset")
 @click.argument('dataset', required=True)
 @click.argument('fid', required=True)
@@ -228,7 +228,7 @@ def put_feature(ctx, dataset, fid, feature, input):
     else:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(name="delete-feature",
+@datasets.command(name="delete-feature",
     short_help="Delete a single feature from a dataset")
 @click.argument('dataset', required=True)
 @click.argument('fid', required=True)
@@ -248,7 +248,7 @@ def delete_feature(ctx, dataset, fid):
     if res.status_code != 204:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(name="batch-update-feature",
+@datasets.command(name="batch-update-feature",
     short_help="Insert, update, or delete multiple features in a dataset")
 @click.argument('dataset', required=True)
 @click.argument('puts', required=False, default=None)
@@ -289,7 +289,7 @@ def batch_update_features(ctx, dataset, puts, deletes, input):
     else:
         raise MapboxCLIException(res.text.strip())
 
-@dataset.command(name="create-tileset",
+@datasets.command(name="create-tileset",
     short_help="Generate a tileset from a dataset")
 @click.argument('dataset', required=True)
 @click.argument('tileset', required=True)

--- a/mapboxcli/scripts/datasets.py
+++ b/mapboxcli/scripts/datasets.py
@@ -1,0 +1,287 @@
+import click
+import json
+
+import mapbox
+from .helpers import MapboxCLIException
+
+@click.group(short_help="Read and write from Mapbox-hosted datasets")
+@click.pass_context
+def dataset(ctx):
+    """Read and write GeoJSON from Mapbox-hosted datasets
+
+    All endpoints require authentication. An access token with
+    appropriate dataset scopes is required, see `mapbox --help`.
+
+    Note that this API is currently a limited-access beta.
+    """
+
+    access_token = (ctx.obj and ctx.obj.get('access_token')) or None
+    service = mapbox.Datasets(access_token=access_token)
+    ctx.obj['service'] = service
+
+@dataset.command(short_help="List datasets")
+@click.option('--output', '-o', default='-', help="Save output to a file")
+@click.pass_context
+def list(ctx, output):
+    """List datasets.
+
+    Prints a list of objects describing datasets.
+
+        $ mapbox dataset list
+
+    All endpoints require authentication. An access token with
+    `datasets:read` scope is required, see `mapbox --help`.
+    """
+
+    stdout = click.open_file(output, 'w')
+    service = ctx.obj.get('service')
+    res = service.list()
+
+    if res.status_code == 200:
+        click.echo(res.text, file=stdout)
+    else:
+        raise MapboxCLIException(res.text.strip())
+
+@dataset.command(short_help="Create an empty dataset")
+@click.option('--name', '-n', default=None, help="Name for the dataset")
+@click.option('--description', '-d', default=None,
+    help="Description for the dataset")
+@click.pass_context
+def create(ctx, name, description):
+    """Create a new dataset.
+
+    Prints a JSON object containing the attributes
+    of the new dataset.
+
+        $ mapbox dataset create
+
+    All endpoints require authentication. An access token with
+    `datasets:write` scope is required, see `mapbox --help`.
+    """
+
+    service = ctx.obj.get('service')
+    res = service.create(name, description)
+
+    if res.status_code == 200:
+        click.echo(res.text)
+    else:
+        raise MapboxCLIException(res.text.strip())
+
+@dataset.command(name="read-dataset",
+    short_help="Return information about a dataset")
+@click.argument('dataset', required=True)
+@click.option('--output', '-o', default='-', help="Save output to a file")
+@click.pass_context
+def read_dataset(ctx, dataset, output):
+    """Read the attributes of a dataset.
+
+    Prints a JSON object containing the attributes
+    of a dataset. The attributes: owner (a Mapbox account),
+    id (dataset id), created (Unix timestamp), modified
+    (timestamp), name (string), and description (string).
+
+        $ mapbox dataset read-dataset dataset-id
+
+    All endpoints require authentication. An access token with
+    `datasets:read` scope is required, see `mapbox --help`.
+    """
+
+    stdout = click.open_file(output, 'w')
+    service = ctx.obj.get('service')
+    res = service.read_dataset(dataset)
+
+    if res.status_code == 200:
+        click.echo(res.text, file=stdout)
+    else:
+        raise MapboxCLIException(res.text.strip())
+
+@dataset.command(name="update-dataset",
+    short_help="Update information about a dataset")
+@click.argument('dataset', required=True)
+@click.option('--name', '-n', default=None, help="Name for the dataset")
+@click.option('--description', '-d', default=None,
+    help="Description for the dataset")
+@click.pass_context
+def update_dataset(ctx, dataset, name, description):
+    """Update the name and description of a dataset.
+
+    Prints a JSON object containing the updated dataset
+    attributes.
+
+        $ mapbox dataset update-dataset dataset-id
+
+    All endpoints require authentication. An access token with
+    `datasets:write` scope is required, see `mapbox --help`.
+    """
+
+    service = ctx.obj.get('service')
+    res = service.update_dataset(dataset, name, description)
+
+    if res.status_code == 200:
+        click.echo(res.text)
+    else:
+        raise MapboxCLIException(res.text.strip())
+
+@dataset.command(name="delete-dataset", short_help="Delete a dataset")
+@click.argument('dataset', required=True)
+@click.pass_context
+def delete_dataset(ctx, dataset):
+    """Delete a dataset.
+
+        $ mapbox dataset delete-dataset dataset-id
+
+    All endpoints require authentication. An access token with
+    `datasets:write` scope is required, see `mapbox --help`.
+    """
+
+    service = ctx.obj.get('service')
+    res = service.delete_dataset(dataset)
+
+    if res.status_code != 204:
+        raise MapboxCLIException(res.text.strip())
+
+@dataset.command(name="list-features", short_help="List features in a dataset")
+@click.option('--output', '-o', default='-', help="Save output to a file")
+@click.argument('dataset', required=True)
+@click.pass_context
+def list_features(ctx, dataset, output):
+    """Get features of a dataset.
+
+    Prints the features of the dataset as a GeoJSON feature collection.
+
+        $ mapbox dataset list-features dataset-id
+
+    All endpoints require authentication. An access token with
+    `datasets:read` scope is required, see `mapbox --help`.
+    """
+
+    stdout = click.open_file(output, 'w')
+    service = ctx.obj.get('service')
+    res = service.list_features(dataset)
+
+    if res.status_code == 200:
+        click.echo(res.text, file=stdout)
+    else:
+        raise MapboxCLIException(res.text.strip())
+
+@dataset.command(name="read-feature",
+    short_help="Read a single feature from a dataset")
+@click.argument('dataset', required=True)
+@click.argument('fid', required=True)
+@click.option('--output', '-o', default='-', help="Save output to a file")
+@click.pass_context
+def read_feature(ctx, dataset, fid, output):
+    """Read a dataset feature.
+
+    Prints a GeoJSON representation of the feature.
+
+        $ mapbox dataset read-feature dataset-id feature-id
+
+    All endpoints require authentication. An access token with
+    `datasets:read` scope is required, see `mapbox --help`.
+    """
+
+    stdout = click.open_file(output, 'w')
+    service = ctx.obj.get('service')
+    res = service.read_feature(dataset, fid)
+
+    if res.status_code == 200:
+        click.echo(res.text, file=stdout)
+    else:
+        raise MapboxCLIException(res.text.strip())
+
+@dataset.command(name="put-feature",
+    short_help="Insert or update a single feature in a dataset")
+@click.argument('dataset', required=True)
+@click.argument('fid', required=True)
+@click.argument('feature', required=False, default=None)
+@click.option('--input', '-i', default='-',
+    help="File containing a feature to put")
+@click.pass_context
+def put_feature(ctx, dataset, fid, feature, input):
+    """Create or update a dataset feature.
+
+    The semantics of HTTP PUT apply: if the dataset has no feature
+    with the given `fid` a new feature will be created. Returns a
+    GeoJSON representation of the new or updated feature.
+
+        $ mapbox dataset put-feature dataset-id feature-id 'geojson-feature'
+
+    All endpoints require authentication. An access token with
+    `datasets:write` scope is required, see `mapbox --help`.
+    """
+
+    if feature is None:
+        stdin = click.open_file(input, 'r')
+        feature = stdin.read()
+
+    feature = json.loads(feature)
+
+    service = ctx.obj.get('service')
+    res = service.update_feature(dataset, fid, feature)
+
+    if res.status_code == 200:
+        click.echo(res.text)
+    else:
+        raise MapboxCLIException(res.text.strip())
+
+@dataset.command(name="delete-feature",
+    short_help="Delete a single feature from a dataset")
+@click.argument('dataset', required=True)
+@click.argument('fid', required=True)
+@click.pass_context
+def delete_feature(ctx, dataset, fid):
+    """Delete a feature.
+
+        $ mapbox dataset delete-feature dataset-id feature-id
+
+    All endpoints require authentication. An access token with
+    `datasets:write` scope is required, see `mapbox --help`.
+    """
+
+    service = ctx.obj.get('service')
+    res = service.delete_feature(dataset, fid)
+
+    if res.status_code != 204:
+        raise MapboxCLIException(res.text.strip())
+
+@dataset.command(name="batch-update-feature",
+    short_help="Insert or update multiple features in a dataset")
+@click.argument('dataset', required=True)
+@click.argument('puts', required=False, default=None)
+@click.argument('deletes', required=False, default=None)
+@click.option('--input', '-i', default='-',
+    help="File containing features to insert, update, and/or delete")
+@click.pass_context
+def delete_feature(ctx, dataset, puts, deletes, input):
+    """Update features of a dataset.
+
+    Up to 100 features may be deleted or modified in one request. PUTS
+    should be a JSON array of GeoJSON features to insert or updated. DELETES
+    should be a JSON array of feature ids to be deleted.
+
+        $ mapbox dataset batch-update-feature dataset-id 'puts' 'deletes'
+
+    All endpoints require authentication. An access token with
+    `datasets:write` scope is required, see `mapbox --help`.
+    """
+
+    if puts:
+        puts = json.loads(puts)
+
+    if deletes:
+        deletes = json.loads(deletes)
+
+    if puts is None and deletes is None:
+        stdin = click.open_file(input, 'r')
+        input = json.loads(stdin.read())
+        puts = input['put']
+        deletes = input['delete']
+
+    service = ctx.obj.get('service')
+    res = service.batch_update_features(dataset, puts, deletes)
+
+    if res.status_code == 200:
+        click.echo(res.text)
+    else:
+        raise MapboxCLIException(res.text.strip())

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,6 @@ setup(name='mapboxcli',
       upload=mapboxcli.scripts.uploads:upload
       staticmap=mapboxcli.scripts.static:staticmap
       surface=mapboxcli.scripts.surface:surface
+      dataset=mapboxcli.scripts.datasets:dataset
       """
       )

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(name='mapboxcli',
       upload=mapboxcli.scripts.uploads:upload
       staticmap=mapboxcli.scripts.static:staticmap
       surface=mapboxcli.scripts.surface:surface
-      dataset=mapboxcli.scripts.datasets:dataset
+      dataset=mapboxcli.scripts.datasets:datasets
       """
       )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,5 +1,6 @@
 import base64
 import re
+import json
 
 from click.testing import CliRunner
 import responses
@@ -645,3 +646,46 @@ def test_cli_dataset_batch_update_feature_stdin():
 
     assert result.exit_code == 0
     assert result.output.strip() == expected
+
+@responses.activate
+def test_cli_dataset_create_tileset():
+    dataset = "dataset-1"
+    name = "test"
+    tileset = "testuser.data"
+    owner = tileset.split('.')[0]
+
+    expected = """{{
+        "id":"ciiae5gc40041mblzuluvu7jr",
+        "name":"{0}",
+        "complete":false,
+        "error":null,
+        "created":"2015-12-17T15:17:46.703Z",
+        "modified":"2015-12-17T15:17:46.703Z",
+        "tileset":"{1}",
+        "owner":"{2}",
+        "progress":0
+    }}""".format(name, tileset, owner)
+
+    responses.add(
+        responses.POST,
+        'https://api.mapbox.com/uploads/v1/{0}?access_token={1}'.format(owner, access_token),
+        status=201, body=expected,
+        match_querystring=True,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'create-tileset',
+         dataset,
+         tileset,
+         '--name', name])
+
+    assert result.exit_code == 0
+    body = json.loads(responses.calls[0].request.body)
+    assert body['url'] == 'mapbox://datasets/{0}/{1}'.format(owner, dataset)
+    assert body['tileset'] == tileset
+    assert body['name'] == name

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,618 @@
+import base64
+
+from click.testing import CliRunner
+import responses
+
+from mapboxcli.scripts.cli import main_group
+import mapbox
+
+username = 'testuser'
+access_token = 'sk.{0}.test'.format(
+    base64.b64encode(b'{"u":"testuser"}').decode('utf-8'))
+
+@responses.activate
+def test_cli_dataset_list_stdout():
+    datasets = """
+        [
+         {{
+          "owner":"{username}",
+          "id":"120c1c5aec87030449dfe2dff4e2a7c8",
+          "name":"first",
+          "description":"the first one",
+          "created":"2015-07-03T00:14:09.622Z",
+          "modified":"2015-07-03T00:14:09.622Z"
+         }},
+         {{
+          "owner":"{username}",
+          "name":"second",
+          "description":"the second one"
+          "id":"18571b87d4c139b6d10911d13cb0561f",
+          "created":"2015-05-05T22:43:10.832Z",
+          "modified":"2015-05-05T22:43:10.832Z"
+         }}
+        ]""".format(username=username)
+
+    datasets = "".join(datasets.split())
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/datasets/v1/{0}?access_token={1}'.format(username, access_token),
+        match_querystring=True,
+        body=datasets, status=200,
+        content_type='application/json')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'list'])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == datasets.strip()
+
+@responses.activate
+def test_cli_dataset_list_tofile(tmpdir):
+    tmpfile = str(tmpdir.join('test.list.json'))
+
+    datasets = """
+        [
+         {{
+          "owner":"{username}",
+          "id":"120c1c5aec87030449dfe2dff4e2a7c8",
+          "name":"first",
+          "description":"the first one",
+          "created":"2015-07-03T00:14:09.622Z",
+          "modified":"2015-07-03T00:14:09.622Z"
+         }},
+         {{
+          "owner":"{username}",
+          "name":"second",
+          "description":"the second one"
+          "id":"18571b87d4c139b6d10911d13cb0561f",
+          "created":"2015-05-05T22:43:10.832Z",
+          "modified":"2015-05-05T22:43:10.832Z"
+         }}
+        ]""".format(username=username)
+
+    datasets = "".join(datasets.split())
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/datasets/v1/{0}?access_token={1}'.format(username, access_token),
+        match_querystring=True,
+        body=datasets, status=200,
+        content_type='application/json')
+
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'list',
+         '--output', tmpfile])
+
+    assert result.exit_code == 0
+    assert open(tmpfile).read().strip() == datasets.strip()
+    assert result.output.strip() == ""
+
+@responses.activate
+def test_cli_dataset_create_noargs():
+    created = """
+    {{"owner":"{username}",
+      "id":"cii9dtexw0039uelz7nzk1lq3",
+      "name":null,
+      "description":null,
+      "created":"2015-12-16T22:20:38.847Z",
+      "modified":"2015-12-16T22:20:38.847Z"}}
+    """.format(username=username)
+
+    created = "".join(created.split())
+
+    responses.add(
+        responses.POST,
+        'https://api.mapbox.com/datasets/v1/{0}?access_token={1}'.format(username, access_token),
+        match_querystring=True,
+        body=created, status=200,
+        content_type='application/json')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'create'])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == created.strip()
+
+@responses.activate
+def test_cli_dataset_create_withargs():
+    name = "the-name"
+    description = "the-description"
+    created = """
+    {{"owner":"{username}",
+      "id":"cii9dtexw0039uelz7nzk1lq3",
+      "name":{name},
+      "description":{description},
+      "created":"2015-12-16T22:20:38.847Z",
+      "modified":"2015-12-16T22:20:38.847Z"}}
+    """.format(username=username, name=name, description=description)
+
+    created = "".join(created.split())
+
+    responses.add(
+        responses.POST,
+        'https://api.mapbox.com/datasets/v1/{0}?access_token={1}'.format(username, access_token),
+        match_querystring=True,
+        body=created, status=200,
+        content_type='application/json')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'create',
+         '--name', name,
+         '-d', description])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == created.strip()
+
+@responses.activate
+def test_cli_dataset_read_dataset_stdout():
+    id = "cii9dtexw0039uelz7nzk1lq3"
+    created = """
+    {{"owner":"{username}",
+      "id":"{id}",
+      "name":null,
+      "description":null,
+      "created":"2015-12-16T22:20:38.847Z",
+      "modified":"2015-12-16T22:20:38.847Z"}}
+    """.format(username=username, id=id)
+
+    created = "".join(created.split())
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}?access_token={2}'.format(username, id, access_token),
+        match_querystring=True,
+        body=created, status=200,
+        content_type='application/json')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'read-dataset', id])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == created.strip()
+
+@responses.activate
+def test_cli_dataset_read_dataset_tofile(tmpdir):
+    tmpfile = str(tmpdir.join('test.read-dataset.json'))
+    id = "cii9dtexw0039uelz7nzk1lq3"
+    created = """
+    {{"owner":"{username}",
+      "id":"{id}",
+      "name":null,
+      "description":null,
+      "created":"2015-12-16T22:20:38.847Z",
+      "modified":"2015-12-16T22:20:38.847Z"}}
+    """.format(username=username, id=id)
+
+    created = "".join(created.split())
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}?access_token={2}'.format(username, id, access_token),
+        match_querystring=True,
+        body=created, status=200,
+        content_type='application/json')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'read-dataset', id,
+         '-o', tmpfile])
+
+    assert result.exit_code == 0
+    assert open(tmpfile).read().strip() == created.strip()
+
+@responses.activate
+def test_cli_dataset_update_dataset():
+    id = "cii9dtexw0039uelz7nzk1lq3"
+    name = "the-name"
+    description = "the-description"
+    created = """
+    {{"owner":"{username}",
+      "id":"{id}",
+      "name":{name},
+      "description":{description},
+      "created":"2015-12-16T22:20:38.847Z",
+      "modified":"2015-12-16T22:20:38.847Z"}}
+    """.format(username=username, id=id, name=name, description=description)
+
+    created = "".join(created.split())
+
+    responses.add(
+        responses.PATCH,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}?access_token={2}'.format(username, id, access_token),
+        match_querystring=True,
+        body=created, status=200,
+        content_type='application/json')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'update-dataset', id,
+         '--name', name,
+         '-d', description])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == created.strip()
+
+@responses.activate
+def test_cli_dataset_delete_dataset():
+    id = "cii9dtexw0039uelz7nzk1lq3"
+
+    responses.add(
+        responses.DELETE,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}?access_token={2}'.format(username, id, access_token),
+        match_querystring=True,
+        status=204
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'delete-dataset', id])
+
+    assert result.exit_code == 0
+
+@responses.activate
+def test_cli_dataset_list_features_stdout():
+    id = "cii9dtexw0039uelz7nzk1lq3"
+    collection='{"type":"FeatureCollection","features":[]}'
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features?access_token={2}'.format(username, id, access_token),
+        match_querystring=True,
+        status=200, body=collection,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'list-features', id])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == collection.strip()
+
+@responses.activate
+def test_cli_dataset_list_features_tofile(tmpdir):
+    tmpfile=str(tmpdir.join('test.list-features.json'))
+    id = "dataset-1"
+    collection='{"type":"FeatureCollection","features":[]}'
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features?access_token={2}'.format(username, id, access_token),
+        match_querystring=True,
+        status=200, body=collection,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'list-features', id,
+         '--output', tmpfile])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+    assert open(tmpfile).read().strip() == collection.strip()
+
+@responses.activate
+def test_cli_dataset_read_feature_stdout():
+    dataset = "cii9dtexw0039uelz7nzk1lq3"
+    id = "abc"
+    feature = """
+        {{
+          "type":"Feature",
+          "id":"{0}",
+          "properties":{{}},
+          "geometry":{{"type":"Point","coordinates":[0,0]}}
+        }}""".format(id)
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features/{2}?access_token={3}'.format(username, dataset, id, access_token),
+        match_querystring=True,
+        status=200, body=feature,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'read-feature', dataset, id])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == feature.strip()
+
+@responses.activate
+def test_cli_dataset_read_feature_tofile(tmpdir):
+    tmpfile = str(tmpdir.join('test.read-feature.json'))
+    dataset = "dataset-2"
+    id = "abc"
+    feature = """
+        {{
+          "type":"Feature",
+          "id":"{0}",
+          "properties":{{}},
+          "geometry":{{"type":"Point","coordinates":[0,0]}}
+        }}""".format(id)
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features/{2}?access_token={3}'.format(username, dataset, id, access_token),
+        match_querystring=True,
+        status=200, body=feature,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'read-feature', dataset, id,
+         '--output', tmpfile])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+    assert open(tmpfile).read().strip() == feature.strip()
+
+@responses.activate
+def test_cli_dataset_put_feature_inline():
+    dataset = "dataset-2"
+    id = "abc"
+
+    feature = """
+        {{
+          "type":"Feature",
+          "id":"{0}",
+          "properties":{{}},
+          "geometry":{{"type":"Point","coordinates":[0,0]}}
+        }}""".format(id)
+
+    feature = "".join(feature.split())
+
+    responses.add(
+        responses.PUT,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features/{2}?access_token={3}'.format(username, dataset, id, access_token),
+        match_querystring=True,
+        status=200, body=feature,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'put-feature', dataset, id, feature])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == feature.strip()
+
+@responses.activate
+def test_cli_dataset_put_feature_fromfile(tmpdir):
+    tmpfile = str(tmpdir.join('test.put-feature.json'))
+    dataset = "dataset-2"
+    id = "abc"
+
+    feature = """
+        {{
+          "type":"Feature",
+          "id":"{0}",
+          "properties":{{}},
+          "geometry":{{"type":"Point","coordinates":[0,0]}}
+        }}""".format(id)
+
+    feature = "".join(feature.split())
+
+    f = open(tmpfile, 'w')
+    f.write(feature)
+    f.close()
+
+    responses.add(
+        responses.PUT,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features/{2}?access_token={3}'.format(username, dataset, id, access_token),
+        match_querystring=True,
+        status=200, body=feature,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'put-feature', dataset, id,
+         '--input', tmpfile])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == feature.strip()
+
+@responses.activate
+def test_cli_dataset_put_feature_stdin():
+    dataset = "dataset-2"
+    id = "abc"
+
+    feature = """
+        {{
+          "type":"Feature",
+          "id":"{0}",
+          "properties":{{}},
+          "geometry":{{"type":"Point","coordinates":[0,0]}}
+        }}""".format(id)
+
+    feature = "".join(feature.split())
+
+    responses.add(
+        responses.PUT,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features/{2}?access_token={3}'.format(username, dataset, id, access_token),
+        match_querystring=True,
+        status=200, body=feature,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'put-feature', dataset, id],
+        input=feature)
+
+    assert result.exit_code == 0
+    assert result.output.strip() == feature.strip()
+
+@responses.activate
+def test_cli_dataset_delete_feature():
+    dataset = "dataset-2"
+    id = "abc"
+
+    responses.add(
+        responses.DELETE,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features/{2}?access_token={3}'.format(username, dataset, id, access_token),
+        match_querystring=True,
+        status=204
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'delete-feature', dataset, id])
+
+    assert result.exit_code == 0
+
+@responses.activate
+def test_cli_dataset_batch_update_feature_inline():
+    dataset = "dataset-3"
+    puts = """
+    [
+      {"type":"Feature","id":"a","properties":{},"geometry":{"type":"Point","coordinates":[0,0]}},
+      {"type":"Feature","id":"b","properties":{},"geometry":{"type":"Point","coordinates":[1,1]}}
+    ]
+    """
+    deletes = '["c"]'
+    puts = "".join(puts.split())
+    expected='{{"put":{0},"delete":{1}}}'.format(puts, deletes)
+
+    responses.add(
+        responses.POST,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features?access_token={2}'.format(username, dataset, access_token),
+        status=200, body=expected,
+        match_querystring=True,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'batch-update-feature', dataset, puts, deletes])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == expected
+
+@responses.activate
+def test_cli_dataset_batch_update_feature_fromfile(tmpdir):
+    tmpfile = str(tmpdir.join('test.batch-update-feature.json'))
+    dataset = "dataset-3"
+    puts = """
+    [
+      {"type":"Feature","id":"a","properties":{},"geometry":{"type":"Point","coordinates":[0,0]}},
+      {"type":"Feature","id":"b","properties":{},"geometry":{"type":"Point","coordinates":[1,1]}}
+    ]
+    """
+    deletes='["c"]'
+    puts = "".join(puts.split())
+    expected='{{"put":{0},"delete":{1}}}'.format(puts, deletes)
+
+    f = open(tmpfile, 'w')
+    f.write(expected)
+    f.close()
+
+    responses.add(
+        responses.POST,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features?access_token={2}'.format(username, dataset, access_token),
+        status=200, body=expected,
+        match_querystring=True,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'batch-update-feature', dataset,
+         '--input', tmpfile])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == expected
+
+@responses.activate
+def test_cli_dataset_batch_update_feature_stdin():
+    dataset = "dataset-3"
+    puts = """
+    [
+      {"type":"Feature","id":"a","properties":{},"geometry":{"type":"Point","coordinates":[0,0]}},
+      {"type":"Feature","id":"b","properties":{},"geometry":{"type":"Point","coordinates":[1,1]}}
+    ]
+    """
+    deletes='["c"]'
+    puts = "".join(puts.split())
+    expected='{{"put":{0},"delete":{1}}}'.format(puts, deletes)
+
+    responses.add(
+        responses.POST,
+        'https://api.mapbox.com/datasets/v1/{0}/{1}/features?access_token={2}'.format(username, dataset, access_token),
+        status=200, body=expected,
+        match_querystring=True,
+        content_type='application/json'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['--access-token', access_token,
+         'dataset',
+         'batch-update-feature', dataset],
+        input=expected)
+
+    assert result.exit_code == 0
+    assert result.output.strip() == expected

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -47,7 +47,7 @@ def test_cli_dataset_list_stdout():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'list'])
 
     assert result.exit_code == 0
@@ -91,7 +91,7 @@ def test_cli_dataset_list_tofile(tmpdir):
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'list',
          '--output', tmpfile])
 
@@ -123,7 +123,7 @@ def test_cli_dataset_create_noargs():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'create'])
 
     assert result.exit_code == 0
@@ -155,7 +155,7 @@ def test_cli_dataset_create_withargs():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'create',
          '--name', name,
          '-d', description])
@@ -188,7 +188,7 @@ def test_cli_dataset_read_dataset_stdout():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'read-dataset', id])
 
     assert result.exit_code == 0
@@ -220,7 +220,7 @@ def test_cli_dataset_read_dataset_tofile(tmpdir):
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'read-dataset', id,
          '-o', tmpfile])
 
@@ -254,7 +254,7 @@ def test_cli_dataset_update_dataset():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'update-dataset', id,
          '--name', name,
          '-d', description])
@@ -277,7 +277,7 @@ def test_cli_dataset_delete_dataset():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'delete-dataset', id])
 
     assert result.exit_code == 0
@@ -298,7 +298,7 @@ def test_cli_dataset_list_features_stdout():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'list-features', id])
 
     assert result.exit_code == 0
@@ -320,7 +320,7 @@ def test_cli_dataset_list_features_pagination():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'list-features', 'dataset-1',
          '--start', id,
          '--limit', '1',
@@ -349,7 +349,7 @@ def test_cli_dataset_list_features_tofile(tmpdir):
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'list-features', id,
          '--output', tmpfile])
 
@@ -381,7 +381,7 @@ def test_cli_dataset_read_feature_stdout():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'read-feature', dataset, id])
 
     assert result.exit_code == 0
@@ -412,7 +412,7 @@ def test_cli_dataset_read_feature_tofile(tmpdir):
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'read-feature', dataset, id,
          '--output', tmpfile])
 
@@ -447,7 +447,7 @@ def test_cli_dataset_put_feature_inline():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'put-feature', dataset, id, feature])
 
     assert result.exit_code == 0
@@ -485,7 +485,7 @@ def test_cli_dataset_put_feature_fromfile(tmpdir):
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'put-feature', dataset, id,
          '--input', tmpfile])
 
@@ -519,7 +519,7 @@ def test_cli_dataset_put_feature_stdin():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'put-feature', dataset, id],
         input=feature)
 
@@ -542,7 +542,7 @@ def test_cli_dataset_delete_feature():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'delete-feature', dataset, id])
 
     assert result.exit_code == 0
@@ -572,7 +572,7 @@ def test_cli_dataset_batch_update_feature_inline():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'batch-update-feature', dataset, puts, deletes])
 
     assert result.exit_code == 0
@@ -608,7 +608,7 @@ def test_cli_dataset_batch_update_feature_fromfile(tmpdir):
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'batch-update-feature', dataset,
          '--input', tmpfile])
 
@@ -640,7 +640,7 @@ def test_cli_dataset_batch_update_feature_stdin():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'batch-update-feature', dataset],
         input=expected)
 
@@ -678,7 +678,7 @@ def test_cli_dataset_create_tileset():
     result = runner.invoke(
         main_group,
         ['--access-token', access_token,
-         'dataset',
+         'datasets',
          'create-tileset',
          dataset,
          tileset,


### PR DESCRIPTION
Adds basic dataset api support:

```
mapbox dataset list
mapbox dataset create
mapbox dataset read-dataset
mapbox dataset delete-dataset
mapbox dataset delete-dataset
mapbox dataset list-features
mapbox dataset read-feature
mapbox dataset put-feature
mapbox dataset delete-feature
mapbox dataset batch-update-feature
mapbox dataset create-tileset
```

The only deviation from the sdk was naming `put-feature` rather than `update-feature`. It seems a little confusing to me to have a method called `update-feature` where the first line of documentation says, "Insert or update". 

Also implements `mapbox dataset create-tileset` which is an `uploads.create` call in disguise.

cc @perrygeo @sgillies for any further tips on writing python code!

refs #21 