### PR TITLE
Add disclaimer about Datasets API to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install mapboxcli
 * [staticmap](#staticmap)
 * [surface](#surface)
 * [upload](#upload)
-* [datasets](#datasets)
+* [datasets](#datasets) (Note: this API is currently in private beta. Any requests to this API from outside of Mapbox will result in a 404.)
 
 For any command that takes waypoints or features as an input you can either specify:
 


### PR DESCRIPTION
It's already mentioned in the README that the Datasets API is in limited-access beta, but this PR makes it all the more obvious.

cc @perrygeo @sgillies @rclark 