### PR TITLE
Add dataset and country geoding options

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,11 +43,12 @@ def test_config_envvar(monkeypatch):
 def test_config_envvar_2(monkeypatch):
     """Get access token from MapboxAccessToken."""
     monkeypatch.setenv('MapboxAccessToken', 'pk.test_config_envvar_2')
+    monkeypatch.delenv('MAPBOX_ACCESS_TOKEN')
     runner = CliRunner()
     result = runner.invoke(main_group, ['config'], catch_exceptions=False)
     assert "Config file" not in result.output
-    assert "access-token = pk.test_config_envvar_2" in result.output
     assert "MapboxAccessToken = pk.test_config_envvar_2" in result.output
+    assert "access-token = pk.test_config_envvar_2" in result.output
     monkeypatch.undo()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,7 @@ def test_config_envvar(monkeypatch):
 def test_config_envvar_2(monkeypatch):
     """Get access token from MapboxAccessToken."""
     monkeypatch.setenv('MapboxAccessToken', 'pk.test_config_envvar_2')
-    monkeypatch.delenv('MAPBOX_ACCESS_TOKEN')
+    monkeypatch.delenv('MAPBOX_ACCESS_TOKEN', raising=False)
     runner = CliRunner()
     result = runner.invoke(main_group, ['config'], catch_exceptions=False)
     assert "Config file" not in result.output

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -184,3 +184,25 @@ def test_cli_geocode_bad_place():
         ['geocoding', '-t', 'spaceship', '--reverse'],
         input='{0},{1}'.format(lon, lat))
     assert result.exit_code == 2
+
+
+def test_cli_geocode_bad_dataset():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main_group,
+        ['geocoding', '-d', 'mapbox.spaceships'],
+        input='Millennium Falcon')
+    assert result.exit_code == 2
+    assert "Invalid value" in result.output
+
+
+def test_cli_geocode_invalid_country():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main_group,
+        ['geocoding', '--country', 'US,Tatooine'],
+        input='Millennium Falcon')
+    assert result.exit_code == 2
+    assert "Invalid value" in result.output

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -42,7 +42,7 @@ def test_cli_geocode_fwd_env_token():
     result = runner.invoke(
         main_group,
         ['geocoding', '--forward', '1600 pennsylvania ave nw'],
-        env={'MapboxAccessToken': 'bogus'})
+        env={'MAPBOX_ACCESS_TOKEN': 'bogus'})
     assert result.exit_code == 0
     assert result.output == '{"query": ["1600", "pennsylvania", "ave", "nw"]}\n'
 
@@ -89,7 +89,7 @@ def test_cli_geocode_reverse_env_token():
         main_group,
         ['geocoding', '--reverse'],
         input='{0},{1}'.format(lon, lat),
-        env={'MapboxAccessToken': 'bogus'})
+        env={'MAPBOX_ACCESS_TOKEN': 'bogus'})
     assert result.exit_code == 0
     assert result.output.strip() == body
 


### PR DESCRIPTION
Resolves #51 
Resolves #40 

I've tested for:
* errors with strictly invalid country codes will be caught by the SDK 
* The datasets are restricted by a `click.Choice`

I have not yet tested for (since this is data dependent and will change over time)
* countries not yet represented in the mapbox geocoder stacks will report back the error from the API's response.