### PR TITLE
Update readme and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ Usage: mapbox geocoding [OPTIONS] [QUERY]
   In forward (the default) mode the query argument shall be an address such
   as '1600 pennsylvania ave nw'.
 
-    $ mapbox geocode '1600 pennsylvania ave nw'
+    $ mapbox geocoding '1600 pennsylvania ave nw'
 
   In reverse mode the query argument shall be a JSON encoded array of
   longitude and latitude (in that order) in decimal degrees.
 
-    $ mapbox geocode --reverse '[-77.4371, 37.5227]'
+    $ mapbox geocoding --reverse '[-77.4371, 37.5227]'
 
   An access token is required, see `mapbox --help`.
 
@@ -264,7 +264,7 @@ Usage: mapbox datasets list [OPTIONS]
 
   Prints a list of objects describing datasets.
 
-      $ mapbox dataset list
+      $ mapbox datasets list
 
   All endpoints require authentication. An access token with `datasets:read`
   scope is required, see `mapbox --help`.
@@ -282,7 +282,7 @@ Usage: mapbox datasets create [OPTIONS]
 
   Prints a JSON object containing the attributes of the new dataset.
 
-      $ mapbox dataset create
+      $ mapbox datasets create
 
   All endpoints require authentication. An access token with
   `datasets:write` scope is required, see `mapbox --help`.
@@ -303,7 +303,7 @@ Usage: mapbox datasets read-dataset [OPTIONS] DATASET
   attributes: owner (a Mapbox account), id (dataset id), created (Unix
   timestamp), modified (timestamp), name (string), and description (string).
 
-      $ mapbox dataset read-dataset dataset-id
+      $ mapbox datasets read-dataset dataset-id
 
   All endpoints require authentication. An access token with `datasets:read`
   scope is required, see `mapbox --help`.
@@ -321,7 +321,7 @@ Usage: mapbox datasets update-dataset [OPTIONS] DATASET
 
   Prints a JSON object containing the updated dataset attributes.
 
-      $ mapbox dataset update-dataset dataset-id
+      $ mapbox datasets update-dataset dataset-id
 
   All endpoints require authentication. An access token with
   `datasets:write` scope is required, see `mapbox --help`.
@@ -338,7 +338,7 @@ Usage: mapbox datasets delete-dataset [OPTIONS] DATASET
 
   Delete a dataset.
 
-      $ mapbox dataset delete-dataset dataset-id
+      $ mapbox datasets delete-dataset dataset-id
 
   All endpoints require authentication. An access token with
   `datasets:write` scope is required, see `mapbox --help`.
@@ -355,7 +355,7 @@ Usage: mapbox datasets list-features [OPTIONS] DATASET
 
   Prints the features of the dataset as a GeoJSON feature collection.
 
-      $ mapbox dataset list-features dataset-id
+      $ mapbox datasets list-features dataset-id
 
   All endpoints require authentication. An access token with `datasets:read`
   scope is required, see `mapbox --help`.
@@ -378,7 +378,7 @@ Usage: mapbox datasets put-feature [OPTIONS] DATASET FID [FEATURE]
   given `fid` a new feature will be created. Returns a GeoJSON
   representation of the new or updated feature.
 
-      $ mapbox dataset put-feature dataset-id feature-id 'geojson-feature'
+      $ mapbox datasets put-feature dataset-id feature-id 'geojson-feature'
 
   All endpoints require authentication. An access token with
   `datasets:write` scope is required, see `mapbox --help`.
@@ -396,7 +396,7 @@ Usage: mapbox datasets read-feature [OPTIONS] DATASET FID
 
   Prints a GeoJSON representation of the feature.
 
-      $ mapbox dataset read-feature dataset-id feature-id
+      $ mapbox datasets read-feature dataset-id feature-id
 
   All endpoints require authentication. An access token with `datasets:read`
   scope is required, see `mapbox --help`.
@@ -412,7 +412,7 @@ Usage: mapbox datasets delete-feature [OPTIONS] DATASET FID
 
   Delete a feature.
 
-      $ mapbox dataset delete-feature dataset-id feature-id
+      $ mapbox datasets delete-feature dataset-id feature-id
 
   All endpoints require authentication. An access token with
   `datasets:write` scope is required, see `mapbox --help`.
@@ -432,7 +432,7 @@ Usage: mapbox datasets batch-update-features [OPTIONS] DATASET [PUTS]
   be a JSON array of GeoJSON features to insert or updated. DELETES should
   be a JSON array of feature ids to be deleted.
 
-      $ mapbox dataset batch-update-feature dataset-id 'puts' 'deletes'
+      $ mapbox datasets batch-update-features dataset-id 'puts' 'deletes'
 
   All endpoints require authentication. An access token with
   `datasets:write` scope is required, see `mapbox --help`.
@@ -448,7 +448,7 @@ Usage: mapbox datasets create-tileset [OPTIONS] DATASET TILESET
 
   Create a vector tileset from a dataset.
 
-      $ mapbox dataset create-tileset dataset-id username.data
+      $ mapbox datasets create-tileset dataset-id username.data
 
   Note that the tileset must start with your username and the dataset must
   be one that you own. To view processing status, visit

--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ $ sudo pip install mapboxcli
 
 If you're interested in contributing, you'll want to [install from master branch](https://github.com/mapbox/mapbox-cli-py/blob/master/CONTRIBUTING.md#contributing).
 
-## Setup 
+## Setup
 
 Use of the `mapbox` command line interface requires an access token.
-Your token is shown on the [API access tokens](https://www.mapbox.com/studio/account/tokens/) page when you are logged in. 
+Your token is shown on the [API access tokens](https://www.mapbox.com/studio/account/tokens/) page when you are logged in.
 The token can be provided on the command line
 
-    $ mapbox --access-token MY_TOKEN ...
+$ mapbox --access-token MY_TOKEN ...
 
 or as an environment variable named `MAPBOX_ACCESS_TOKEN`
 
-    $ export MAPBOX_ACCESS_TOKEN=MY_TOKEN
-    $ mapbox ...
+$ export MAPBOX_ACCESS_TOKEN=MY_TOKEN
+$ mapbox ...
 
 
 
@@ -62,18 +62,17 @@ Note that functions that accept points only, any non-point feature is filtered o
 
 ### directions
 ```
-Usage: mapbox directions [OPTIONS] [WAYPOINTS]...
+Usage: mapbox directions [OPTIONS] FEATURES...
 
   Calculate optimal route with turn-by-turn directions between up to 25
   waypoints.
 
-    $ mapbox directions "[-122.681032, 45.528334]" "[-122.71679,
-    45.525135]"
+    $ mapbox directions "[-122.681032, 45.528334]" "[-122.71679, 45.525135]"
 
   An access token is required, see `mapbox --help`.
 
 Options:
-  --profile [mapbox.driving|mapbox.walking|mapbox.cycling]
+  --profile [mapbox.driving|mapbox.cycling|mapbox.walking]
                                   Mapbox direction profile id
   --alternatives / --no-alternatives
                                   Generate alternative routes?
@@ -89,7 +88,7 @@ Options:
 
 ### distance
 ```
-Usage: mapbox distance [OPTIONS] [WAYPOINTS]...
+Usage: mapbox distance [OPTIONS] FEATURES...
 
   The Distance API returns all travel times between many points (also known
   as Distance Matrix). This is often used as input for solving routing
@@ -103,7 +102,7 @@ Usage: mapbox distance [OPTIONS] [WAYPOINTS]...
   An access token is required, see `mapbox --help`.
 
 Options:
-  --profile [driving|walking|cycling]
+  --profile [driving|cycling|walking]
                                   Mapbox direction profile id
   -o, --output TEXT               Save output to a file.
   --help                          Show this message and exit.
@@ -129,37 +128,38 @@ Usage: mapbox geocoding [OPTIONS] [QUERY]
   An access token is required, see `mapbox --help`.
 
 Options:
-  --forward / --reverse  Perform a forward or reverse geocode. [default:
-                         forward]
-  -i, --include          Include HTTP headers in the output.
-  --lat FLOAT            Bias results toward this latitude (decimal degrees).
-                         --lon is also required.
-  --lon FLOAT            Bias results toward this longitude (decimal degrees).
-                         --lat is also required.
-  -t, --place-type NAME  Restrict results to one or more of these place types:
-                         ['address', 'country', 'neighborhood', 'place',
-                         'poi', 'postcode', 'region'].
-  -o, --output TEXT      Save output to a file.
-  --help                 Show this message and exit.
+  --forward / --reverse           Perform a forward or reverse geocode.
+                                  [default: forward]
+  -i, --include                   Include HTTP headers in the output.
+  --lat FLOAT                     Bias results toward this latitude (decimal
+                                  degrees). --lon is also required.
+  --lon FLOAT                     Bias results toward this longitude (decimal
+                                  degrees). --lat is also required.
+  -t, --place-type NAME           Restrict results to one or more place types.
+  -o, --output TEXT               Save output to a file.
+  -d, --dataset [mapbox.places|mapbox.places-permanent]
+                                  Source dataset for geocoding, [default:
+                                  mapbox.places]
+  --country TEXT                  Restrict forward geocoding to specified
+                                  country codes,comma-separated
+  --help                          Show this message and exit.
 ```
 
 ### mapmatching
-
 ```
-$ mapbox mapmatching --help
-Usage: mapbox mapmatching [OPTIONS] [LINESTRING_FEATURE]
+Usage: mapbox mapmatching [OPTIONS] FEATURES...
 
   Mapbox Map Matching API lets you use snap your GPS traces to the
   OpenStreetMap road and path network.
 
-        $ mapbox mapmatching traces.geojson
+        $ mapbox mapmatching trace.geojson
 
   An access token is required, see `mapbox --help`.
 
 Options:
   --gps-precision INTEGER         Assumed precision of tracking device
                                   (default 4 meters)
-  --profile [mapbox.driving|mapbox.walking|mapbox.cycling]
+  --profile [mapbox.driving|mapbox.cycling|mapbox.walking]
                                   Mapbox profile id
   --help                          Show this message and exit.
 ```
@@ -171,10 +171,9 @@ Usage: mapbox staticmap [OPTIONS] MAPID OUTPUT
   Generate static map images from existing Mapbox map ids. Optionally
   overlay with geojson features.
 
-    $ mapbox staticmap \
-        --features features.geojson mapbox.satellite out.png
-    $ mapbox staticmap \
-        --lon -61.7 --lat 12.1 --zoom 12 mapbox.satellite out2.png
+    $ mapbox staticmap --features features.geojson mapbox.satellite out.png
+    $ mapbox staticmap --lon -61.7 --lat 12.1 --zoom 12 mapbox.satellite
+    out2.png
 
   An access token is required, see `mapbox --help`.
 
@@ -189,7 +188,7 @@ Options:
 
 ### surface
 ```
-Usage: mapbox surface [OPTIONS] MAPID LAYER FIELDS [WAYPOINTS]...
+Usage: mapbox surface [OPTIONS] MAPID LAYER FIELDS FEATURES...
 
   Mapbox Surface API enables flexible querying of data stored in vector
   tiles on Mapbox, to create results like elevation profiles.
@@ -212,7 +211,7 @@ Options:
 
 ### upload
 ```
-Usage: mapbox upload [OPTIONS] TILESET INFILE
+Usage: mapbox upload [OPTIONS] TILESET [INFILE]
 
   Upload data to Mapbox accounts. All endpoints require authentication.
   Uploaded data lands at https://www.mapbox.com/data/ and can be used in new
@@ -243,18 +242,18 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  batch-update-feature  Insert, update, or delete multiple features in a
-                        dataset
-  create                Create an empty dataset
-  create-tileset        Generate a tileset from a dataset
-  delete-dataset        Delete a dataset
-  delete-feature        Delete a single feature from a dataset
-  list                  List datasets
-  list-features         List features in a dataset
-  put-feature           Insert or update a single feature in a dataset
-  read-dataset          Return information about a dataset
-  read-feature          Read a single feature from a dataset
-  update-dataset        Update information about a dataset
+  batch-update-features  Insert, update, or delete multiple features in a
+                         dataset
+  create                 Create an empty dataset
+  create-tileset         Generate a tileset from a dataset
+  delete-dataset         Delete a dataset
+  delete-feature         Delete a single feature from a dataset
+  list                   List datasets
+  list-features          List features in a dataset
+  put-feature            Insert or update a single feature in a dataset
+  read-dataset           Return information about a dataset
+  read-feature           Read a single feature from a dataset
+  update-dataset         Update information about a dataset
 ```
 
 ### datasets list
@@ -422,9 +421,10 @@ Options:
   --help  Show this message and exit.
 ```
 
-### datasets batch-update-feature
+### datasets batch-update-features
 ```
-Usage: mapbox datasets batch-update-feature [OPTIONS] DATASET [PUTS] [DELETES]
+Usage: mapbox datasets batch-update-features [OPTIONS] DATASET [PUTS]
+                                             [DELETES]
 
   Update features of a dataset.
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ Use of the `mapbox` command line interface requires an access token.
 Your token is shown on the [API access tokens](https://www.mapbox.com/studio/account/tokens/) page when you are logged in.
 The token can be provided on the command line
 
+```
 $ mapbox --access-token MY_TOKEN ...
+```
 
 or as an environment variable named `MAPBOX_ACCESS_TOKEN`
 
+```
 $ export MAPBOX_ACCESS_TOKEN=MY_TOKEN
 $ mapbox ...
-
-
-
-
+```
 
 ## Usage
 

--- a/mapboxcli/scripts/datasets.py
+++ b/mapboxcli/scripts/datasets.py
@@ -32,7 +32,7 @@ def list(ctx, output):
 
     Prints a list of objects describing datasets.
 
-        $ mapbox dataset list
+        $ mapbox datasets list
 
     All endpoints require authentication. An access token with
     `datasets:read` scope is required, see `mapbox --help`.
@@ -59,7 +59,7 @@ def create(ctx, name, description):
     Prints a JSON object containing the attributes
     of the new dataset.
 
-        $ mapbox dataset create
+        $ mapbox datasets create
 
     All endpoints require authentication. An access token with
     `datasets:write` scope is required, see `mapbox --help`.
@@ -87,7 +87,7 @@ def read_dataset(ctx, dataset, output):
     id (dataset id), created (Unix timestamp), modified
     (timestamp), name (string), and description (string).
 
-        $ mapbox dataset read-dataset dataset-id
+        $ mapbox datasets read-dataset dataset-id
 
     All endpoints require authentication. An access token with
     `datasets:read` scope is required, see `mapbox --help`.
@@ -116,7 +116,7 @@ def update_dataset(ctx, dataset, name, description):
     Prints a JSON object containing the updated dataset
     attributes.
 
-        $ mapbox dataset update-dataset dataset-id
+        $ mapbox datasets update-dataset dataset-id
 
     All endpoints require authentication. An access token with
     `datasets:write` scope is required, see `mapbox --help`.
@@ -137,7 +137,7 @@ def update_dataset(ctx, dataset, name, description):
 def delete_dataset(ctx, dataset):
     """Delete a dataset.
 
-        $ mapbox dataset delete-dataset dataset-id
+        $ mapbox datasets delete-dataset dataset-id
 
     All endpoints require authentication. An access token with
     `datasets:write` scope is required, see `mapbox --help`.
@@ -167,7 +167,7 @@ def list_features(ctx, dataset, reverse, start, limit, output):
 
     Prints the features of the dataset as a GeoJSON feature collection.
 
-        $ mapbox dataset list-features dataset-id
+        $ mapbox datasets list-features dataset-id
 
     All endpoints require authentication. An access token with
     `datasets:read` scope is required, see `mapbox --help`.
@@ -194,7 +194,7 @@ def read_feature(ctx, dataset, fid, output):
 
     Prints a GeoJSON representation of the feature.
 
-        $ mapbox dataset read-feature dataset-id feature-id
+        $ mapbox datasets read-feature dataset-id feature-id
 
     All endpoints require authentication. An access token with
     `datasets:read` scope is required, see `mapbox --help`.
@@ -225,7 +225,7 @@ def put_feature(ctx, dataset, fid, feature, input):
     with the given `fid` a new feature will be created. Returns a
     GeoJSON representation of the new or updated feature.
 
-        $ mapbox dataset put-feature dataset-id feature-id 'geojson-feature'
+        $ mapbox datasets put-feature dataset-id feature-id 'geojson-feature'
 
     All endpoints require authentication. An access token with
     `datasets:write` scope is required, see `mapbox --help`.
@@ -254,7 +254,7 @@ def put_feature(ctx, dataset, fid, feature, input):
 def delete_feature(ctx, dataset, fid):
     """Delete a feature.
 
-        $ mapbox dataset delete-feature dataset-id feature-id
+        $ mapbox datasets delete-feature dataset-id feature-id
 
     All endpoints require authentication. An access token with
     `datasets:write` scope is required, see `mapbox --help`.
@@ -284,7 +284,7 @@ def batch_update_features(ctx, dataset, puts, deletes, input):
     should be a JSON array of GeoJSON features to insert or updated.
     DELETES should be a JSON array of feature ids to be deleted.
 
-        $ mapbox dataset batch-update-feature dataset-id 'puts' 'deletes'
+        $ mapbox datasets batch-update-features dataset-id 'puts' 'deletes'
 
     All endpoints require authentication. An access token with
     `datasets:write` scope is required, see `mapbox --help`.
@@ -320,7 +320,7 @@ def batch_update_features(ctx, dataset, puts, deletes, input):
 def create_tileset(ctx, dataset, tileset, name):
     """Create a vector tileset from a dataset.
 
-        $ mapbox dataset create-tileset dataset-id username.data
+        $ mapbox datasets create-tileset dataset-id username.data
 
     Note that the tileset must start with your username and the dataset
     must be one that you own. To view processing status, visit

--- a/mapboxcli/scripts/geocoding.py
+++ b/mapboxcli/scripts/geocoding.py
@@ -74,12 +74,12 @@ def geocoding(ctx, query, forward, include_headers, lat, lon,
     In forward (the default) mode the query argument shall be an address
     such as '1600 pennsylvania ave nw'.
 
-      $ mapbox geocode '1600 pennsylvania ave nw'
+      $ mapbox geocoding '1600 pennsylvania ave nw'
 
     In reverse mode the query argument shall be a JSON encoded array
     of longitude and latitude (in that order) in decimal degrees.
 
-      $ mapbox geocode --reverse '[-77.4371, 37.5227]'
+      $ mapbox geocoding --reverse '[-77.4371, 37.5227]'
 
     An access token is required, see `mapbox --help`.
     """


### PR DESCRIPTION
Thanks to @ajashton for noticing some naming inconsistencies in the README and command help text. This brings everything up to date.

@sgillies should be good to go