### PR TITLE
Add a click progress bar for uploads

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Next
 ----
-- Add a uploads progress bar.
+- Add a uploads progress bar (#86).
 
 0.5.1 (2015-11-22)
 ------------------

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Next
+----
+- Add a uploads progress bar.
+
 0.5.1 (2015-11-22)
 ------------------
 - Use mapbox sdk 0.10.1

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,0 @@
-https://github.com/mapbox/mapbox-cli-py/releases/download/0.1.0/boto3-1.2.2-py2.py3-none-any.whl

--- a/mapboxcli/__init__.py
+++ b/mapboxcli/__init__.py
@@ -1,3 +1,3 @@
 # Command line interface to Mapbox Web Services
 
-__version__ = '0.5.1'
+__version__ = '0.6.0'

--- a/mapboxcli/scripts/uploads.py
+++ b/mapboxcli/scripts/uploads.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 import os
+import sys
 
 import click
 
@@ -66,7 +67,8 @@ def upload(ctx, args, name, patch):
     def staging_cb(num_bytes):
         pass
 
-    with click.progressbar(length=filelen, label='Staging data') as bar:
+    with click.progressbar(length=filelen, label='Staging data',
+                           file=sys.stderr) as bar:
 
         def callback(num_bytes):
             """Update the progress bar"""

--- a/mapboxcli/scripts/uploads.py
+++ b/mapboxcli/scripts/uploads.py
@@ -64,9 +64,6 @@ def upload(ctx, args, name, patch):
     if name is None:
         name = tileset.split(".")[-1]
 
-    def staging_cb(num_bytes):
-        pass
-
     with click.progressbar(length=filelen, label='Staging data',
                            file=sys.stderr) as bar:
 
@@ -74,12 +71,8 @@ def upload(ctx, args, name, patch):
             """Update the progress bar"""
             bar.update(num_bytes)
 
-        try:
-            res = service.upload(infile, tileset, name, patch=patch,
-                                 callback=callback)
-
-        except (mapbox.errors.ValidationError, IOError) as exc:
-            raise click.BadParameter(str(exc))
+        res = service.upload(infile, tileset, name, patch=patch,
+                             callback=callback)
 
     if res.status_code == 201:
         click.echo(res.text)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/mapbox/mapbox-sdk-py.git@upload-progress-open-bar#egg=mapbox
+-e git+https://github.com/mapbox/mapbox-sdk-py.git#egg=mapbox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/mapbox/mapbox-sdk-py.git#egg=mapbox
+-e git+https://github.com/mapbox/mapbox-sdk-py.git@upload-progress-open-bar#egg=mapbox

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,8 @@ setup(name='mapboxcli',
           'click',
           'click-plugins',
           'cligj>=0.4',
-          'mapbox>=0.10.1',
-          'six'
-      ],
+          'mapbox>=0.11',
+          'six'],
       extras_require={
           'test': ['coveralls', 'pytest>=2.8', 'pytest-cov', 'responses'],
       },

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,4 @@ setup(name='mapboxcli',
       staticmap=mapboxcli.scripts.static:staticmap
       surface=mapboxcli.scripts.surface:surface
       dataset=mapboxcli.scripts.datasets:datasets
-      """
-      )
+      """)


### PR DESCRIPTION
A work in progress, you might say.

@perrygeo @mapsam an obvious issue/problem is that this command is already printing some JSON to stdout and now the progress bar is added to that, meaning that you can no longer send the outout directly to, say, jq.

```
$ mapbox upload ~/code/Fiona/tests/data/coutwildrnp.json coutwildrnp
Staging data  [####################################]  100%
{"id":"ciy32qhe6002t2wmqjc9ojwo3","name":"coutwildrnp","complete":false,"error":null,"created":"2017-01-18T14:59:06.516Z","modified":"2017-01-18T14:59:06.516Z","tileset":"sgillies.coutwildrnp","owner":"sgillies","progress":0}
```

Also a meaningful progress bar in the truly streaming case will be elusive because there's no known denominator. But mapbox-upload doesn't support unbounded streaming as it is currently written, we copy stdin to an in-memory file and then pass that file to the AWS SDK.