### PR TITLE
Added Python 3.6 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 - pypy
 cache:
   directories:
@@ -19,6 +20,9 @@ install:
 - pip install -r requirements-dev.txt
 - pip install -e .[test]
 - pip list
+before_script:
+- pip install flake8  # 127 == GitHub editor width
+- if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then flake8 . --count --max-line-length=127 --statistics --exit-zero; fi
 script:
 - py.test --cov mapboxcli --cov-report term-missing
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,24 @@ from setuptools import setup, find_packages
 # Parse the version from the mapbox module.
 with open('mapboxcli/__init__.py') as f:
     for line in f:
-        if line.find("__version__") >= 0:
-            version = line.split("=")[1].strip()
-            version = version.strip('"')
-            version = version.strip("'")
+        if "__version__" in line:
+            version = line.split("=")[1].strip().strip('"').strip("'")
             continue
 
 setup(name='mapboxcli',
       version=version,
       description="Command line interface to Mapbox Web Services",
-      classifiers=[],
+      classifiers=['Development Status :: 5 - Production/Stable',
+                   'Environment :: Console',
+                   'Intended Audience :: Developers',
+                   'License :: OSI Approved :: MIT License',
+                   'Programming Language :: Python',
+                   'Programming Language :: Python :: 2.7',
+                   'Programming Language :: Python :: 3',
+                   'Programming Language :: Python :: 3.3',
+                   'Programming Language :: Python :: 3.4',
+                   'Programming Language :: Python :: 3.5',
+                   'Programming Language :: Python :: 3.6'],
       keywords='',
       author="Sean Gillies",
       author_email='sean@mapbox.com',


### PR DESCRIPTION
Also added flake8 testing to all version except Python 2.6.

Do you really need to support Python 2.6?  Its End of Life was in 2013... https://docs.python.org/devguide/index.html#branchstatus