### PR TITLE
Update README.md with per user install using pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ $ brew install mapbox/cli/mapbox
 (venv)$ pip install mapboxcli
 ```
 
+Installing locally without a virtual environment using
+```
+$ pip install --user mapboxcli
+```
+You'll then need to include ~/.local/bin in your $PATH.
+
 Installing globally is *not recommended* but some users may want to do so under certain circumstances
 ```
 $ sudo pip install mapboxcli


### PR DESCRIPTION
Setting up a venv can be hard and deter people looking to use the tool, and installing with sudo isn't always desired. This PR guides the use of pip install --user for a simple install procedure without using sudo.