### PR TITLE
ascii progressbar

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.6.1 (2017-04-10)
+------------------
+- Bugfix, ascii charaters in upload progressbar (see #98)
+
 0.6.0 (2017-01-23)
 ------------------
 - Breaking change: in mapbox-upload TILESET is now the first positional

--- a/mapboxcli/__init__.py
+++ b/mapboxcli/__init__.py
@@ -1,3 +1,3 @@
 # Command line interface to Mapbox Web Services
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/mapboxcli/scripts/uploads.py
+++ b/mapboxcli/scripts/uploads.py
@@ -60,7 +60,7 @@ def upload(ctx, tileset, datasource, name, patch):
                        if hasattr(sourcefile, 'getbuffer') else 1)
 
         with click.progressbar(length=filelen, label='Uploading data source',
-                               fill_char=u"\u2588", empty_char='-',
+                               fill_char="#", empty_char='-',
                                file=sys.stderr) as bar:
 
             def callback(num_bytes):


### PR DESCRIPTION
There is a [strange bug](https://github.com/mapbox/mapbox-cli-py/issues/97#issuecomment-293063691) in the interaction between `boto3` and `click` progressbar. The safest workaround: use ascii characters in the progressbar.

Fixes #97