### PR TITLE
fix upload usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,15 +221,15 @@ Options:
 
 ### upload
 ```
-Usage: mapbox upload [OPTIONS] [INFILE] TILESET
+Usage: mapbox upload [OPTIONS] TILESET [INFILE]
 
   Upload data to Mapbox accounts. All endpoints require authentication.
   Uploaded data lands at https://www.mapbox.com/data/ and can be used in new
   or existing projects.
 
-  You can specify the input file and tileset id
+  You can specify the tileset id and input file
 
-    $ mapbox upload mydata.geojson username.data
+    $ mapbox upload username.data mydata.geojson
 
   Or specify just the tileset id and take an input file on stdin
 


### PR DESCRIPTION
This was changed per below, but the example wasn't updated:

0.6.0 (2017-01-23)
------------------
- Breaking change: in mapbox-upload TILESET is now the first positional
  argument and source file the second, reversing the order set in 0.4.0 (#85).