### PR TITLE
pin mapbox-sdk-py to 0.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='mapboxcli',
           'click',
           'click-plugins',
           'cligj>=0.4',
-          'mapbox>=0.12.2',
+          'mapbox==0.14.0',
           'six'],
       extras_require={
           'test': ['coveralls', 'pytest>=2.8', 'pytest-cov', 'responses',


### PR DESCRIPTION
Newer versions of mapbox-sdk-py have some incompatible changes, to be resolved in 0.8 release.

For now, releasing this as a 0.7.1 bugfix 