### PR TITLE
Add archival language to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
+# PAUSED DEVELOPMENT
+
+Since [the SDK that it wraps](https://github.com/mapbox/mapbox-sdk-py/blob/master/CONTRIBUTING.md#attention-this-project-is-paused) has been deprecated, we have also archived this CLI. We encourage you to migrate to [the equivalent tiling and upload endpoints.](https://docs.mapbox.com/api/maps/mapbox-tiling-service/)
+
 # Contributing
-
-If you want to add an issue or pull request, please ensure that the [existing issues](https://github.com/mapbox/mapbox-cli-py/issues?utf8=✓&q=) don't already cover your question or contribution.
-
-To get started contributing code to the `mapbox-cli-py` project:
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# PAUSED DEVELOPMENT
+
+Since [the SDK that it wraps](https://github.com/mapbox/mapbox-sdk-py/blob/master/CONTRIBUTING.md#attention-this-project-is-paused) has been deprecated, we have also archived this CLI. We encourage you to migrate to [the equivalent tiling and upload endpoints.](https://docs.mapbox.com/api/maps/mapbox-tiling-service/)
+
 # mapbox-cli-py
 
 [![Build Status](https://travis-ci.org/mapbox/mapbox-cli-py.svg?branch=master)](https://travis-ci.org/mapbox/mapbox-cli-py) [![Coverage Status](https://coveralls.io/repos/mapbox/mapbox-cli-py/badge.svg?branch=master&service=github)](https://coveralls.io/github/mapbox/mapbox-cli-py?branch=master)


### PR DESCRIPTION
Ahead of project deprecation. We recommend users migrate to the standard endpoints [documented here](https://docs.mapbox.com/api/maps/mapbox-tiling-service/).